### PR TITLE
remove duplicate import of MultidimensionalFilter.css

### DIFF
--- a/css/widgets-1.css
+++ b/css/widgets-1.css
@@ -17,7 +17,6 @@
 @import url("../dijit/css/PopupFont.css");
 @import url("../dijit/css/Popup.css");
 @import url("../dijit/css/PopupMobile.css");
-@import url("../dijit/css/MultidimensionalFilter.css");
 @import url("../dijit/css/ImageServiceMeasure.css");
 @import url("../dijit/css/Print.css");
 @import url("../dijit/css/Scalebar.css");


### PR DESCRIPTION
The duplicate import leads to duplicated css statements and increases file footprint.