### PR TITLE
Rename SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # @arcgis/core
 
-A minified, unbuilt version of the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/) ES modules.
+A minified, unbuilt version of the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/) ES modules.
 
 ## Features
 
-You can install these modules via [npm](https://npmjs.org/) and then use them directly in a framework such as [React](https://reactjs.org/), [Vue.js](https://vuejs.org) or [Angular](https://cli.angular.io/). Or, you can also create your own custom builds with [Webpack](https://webpackjs.org) or [rollup.js](https://rollupjs.org/guide/en/).
+For an overview of the SDK, visit the [developer documentation](https://developers.arcgis.com/javascript/latest/key-features/) site.
+
+You can install these modules with [npm](https://npmjs.org/) and then use them directly in a framework such as [React](https://reactjs.org/), [Vue.js](https://vuejs.org) or [Angular](https://cli.angular.io/). Or, you can also create your own custom builds with [Webpack](https://webpackjs.org) or [rollup.js](https://rollupjs.org/guide/en/). 
+
+The SDK includes [TypeScript](https://www.typescriptlang.org/) type definitions. The `.d.ts` declaration files are bundled with the install.
 
 Sample applications can be found at [github.com/jsapi-resources/](https://github.com/Esri/jsapi-resources/tree/master/esm-samples).
 
@@ -18,31 +22,33 @@ npm install @arcgis/core
 
 ## Configure CSS
 
-Set the CSS to the same version as the installed API modules. You can verify the installed API version by running `npm list @arcgis/core`.  If you are working with local assets skip to the *Manage assets locally* section.
+Set the CSS to the same version as the installed SDK modules. You can verify the installed SDK version by running `npm list @arcgis/core`.  If you are working with local assets skip to the *Manage assets locally* section.
 
-The first example shows importing CSS for production API version `4.19.0`:
+The first example shows importing CSS for production SDK version `4.25.0`:
 
 *index.css* 
 
 ```css
-@import "https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css";
+@import "https://js.arcgis.com/4.25/@arcgis/core/assets/esri/themes/light/main.css";
 ```
 
-The second example shows importing CSS for `next` API version `4.19.0-next.20210324`:
+The second example shows importing CSS for `next` SDK version `4.19.0-next.20210324`:
 
 *index.css*
 
 ```css
-@import "https://cdn.jsdelivr.net/npm/@arcgis/core@4.19.0-next.20210324/assets/esri/themes/light/main.css";
+@import "https://cdn.jsdelivr.net/npm/@arcgis/core@4.25.0-next.20220921/assets/esri/themes/light/main.css";
 ```
 
 ## Working with assets
 
-For most local builds, the API's assets are automatically pulled from a CDN at runtime and there is no need for additional configuration. The assets include styles, images, web workers, wasm and localization files. Production versions of the API use the ArcGIS CDN, and `next` builds (e.g. `4.19.0-next.20210324`) use jsDelivr, similar to the CSS example above. 
+The default configuration for local builds is for the SDK to automatically pull assets from a CDN at runtime, there is no need for additional configuration. The assets include styles, images, web workers, wasm and localization files. Production versions of the SDK's assets are hosted on the ArcGIS CDN, and `next` builds (e.g. `4.25.0-next.20220921`) use assets hosted on the jsDelivr CDN.
 
 ### Manage assets locally
 
 If you need to manage the assets locally, copy them into your project from `/node_modules/@arcgis/core/assets`, and then set `config.assetsPath` to insure requests for assets are resolved correctly. A simple way to accomplish this is to configure an npm script that runs during your build process. For example, use npm to install `ncp` and configure a script in package.json to copy the folder. 
+
+**Important:** Every time you upgrade the SDK, be sure to recopy the new version of the assets to your project. This ensures the assets stay synchronized.
 
 Here’s a React example:
 
@@ -115,22 +121,22 @@ Windows users can use [`xcopy`](https://docs.microsoft.com/en-us/windows-server/
 
 ## Requirements
 
-Use of the ArcGIS API for JavaScript is subject to the terms described in the product-specific [terms of use.](https://www.esri.com/en-us/legal/terms/product-specific-scope-of-use) Learn more about licensing [here](https://developers.arcgis.com/javascript/latest/licensing/).
+Use of the ArcGIS Maps SDK for JavaScript is subject to the terms described in the product-specific [terms of use.](https://www.esri.com/en-us/legal/terms/product-specific-scope-of-use) Learn more about licensing [here](https://developers.arcgis.com/javascript/latest/licensing/).
 
 ## Resources
 
-- [ArcGIS for JavaScript](https://developers.arcgis.com/javascript/)
+- [ArcGIS Maps SDK JavaScript](https://developers.arcgis.com/javascript/)
 - [http://blogs.esri.com/esri/arcgis/tag/javascript/](https://blogs.esri.com/esri/arcgis/tag/javascript/)
 - [twitter@ArcGISJSAPI](https://twitter.com/ArcGISJSAPI)
 
 ## Issues
 
-- General questions about using these modules or the ArcGIS API for JavaScript? See the [Esri developer community](https://community.esri.com/t5/arcgis-api-for-javascript/ct-p/arcgis-api-for-javascript).
+- General questions about using these modules or the ArcGIS Maps SDK for JavaScript? See the [Esri developer community](https://community.esri.com/t5/arcgis-api-for-javascript/ct-p/arcgis-api-for-javascript).
 - [Technical support](https://support.esri.com/).
 
 ## Licensing
 
-COPYRIGHT © 2021 Esri
+COPYRIGHT © 2022 Esri
 
 All rights reserved under the copyright laws of the United States
 and applicable international laws, treaties, and conventions.


### PR DESCRIPTION
This PR replaces all instances of the old naming convention with the new name. It roughly follows a convention of using the full name once per section followed by just using shorthand "SDK".  This PR syncs up the README's content with the NPM README.

The plan is to merge this change on or before Dec 14.

For more information see the [Introducing the ArcGIS Map SDKs](https://www.esri.com/arcgis-blog/products/developers/announcements/introducing-the-arcgis-maps-sdks/) blog post. 

Items of note:
* This PR does not create a new version of the SDK.

cc @dasa 