### PR TITLE
chore: update for 4.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This repository is used as a reference for the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/) widget styles documentation.
 
-If you are starting a new project, we recommend using [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules.
+If you are starting a new project, we recommend using a local build with components or @arcgis/core. See the [Get started with npm](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide topic for more information.
 
+**Looking for 3.x?** The ArcGIS for JavaScript 3.x has been retired. See the [retirement announcement](https://www.esri.com/arcgis-blog/products/js-api-arcgis/developers/arcgis-api-for-javascript-version-3-x-retirement/) for more information.
 
 ## Requirements
 

--- a/assets/esri/themes/base/widgets/_BasemapLayerList.scss
+++ b/assets/esri/themes/base/widgets/_BasemapLayerList.scss
@@ -15,6 +15,22 @@
     margin-inline-start: 0.25rem;
   }
 
+  .esri-basemap-layer-list__item-catalog-icon {
+    margin-inline-end: 0;
+  }
+
+  .esri-basemap-layer-list__item-action-image {
+    @include layerListActionImage();
+  }
+
+  .esri-basemap-layer-list__action-menu .esri-basemap-layer-list__action-group {
+    display: none;
+  }
+
+  .esri-basemap-layer-list__action-menu[open] .esri-basemap-layer-list__action-group {
+    display: flex;
+  }
+
   .esri-basemap-layer-list__visible-icon {
     visibility: hidden;
   }
@@ -27,7 +43,7 @@
     }
   }
 
-  .esri-basemap-layer-list__item--invisible-at-scale {
+  .esri-basemap-layer-list__item--invisible {
     color: $interactive-font-color--disabled;
   }
 

--- a/assets/esri/themes/base/widgets/_BuildingDisciplinesTree.scss
+++ b/assets/esri/themes/base/widgets/_BuildingDisciplinesTree.scss
@@ -41,6 +41,12 @@
     padding-bottom: $side-spacing--quarter;
     font-size: $font-size;
     font-weight: $font-weight--light;
+
+    span {
+      min-width: 0;
+      word-break: break-word;
+      text-wrap: pretty;
+    }
   }
 
   .#{$collapse-toggle} {

--- a/assets/esri/themes/base/widgets/_CatalogLayerList.scss
+++ b/assets/esri/themes/base/widgets/_CatalogLayerList.scss
@@ -1,0 +1,103 @@
+@mixin catalogLayerList() {
+  .esri-catalog-layer-list {
+    display: flex;
+  }
+
+  .esri-catalog-layer-list__filter-no-results {
+    @include layerListFilterNoResults();
+  }
+
+  .esri-catalog-layer-list__item {
+    --calcite-list-item-spacing-indent: 2rem;
+    --calcite-list-item-icon-center: 8.5px;
+  }
+
+  .esri-catalog-layer-list__item-temporary-icon {
+    margin-inline-start: 0.25rem;
+  }
+
+  .esri-catalog-layer-list__item-table-icon {
+    margin-inline-end: 0;
+  }
+
+  .esri-catalog-layer-list__item-action-image {
+    @include layerListActionImage();
+  }
+
+  .esri-catalog-layer-list__action-menu .esri-catalog-layer-list__action-group {
+    display: none;
+  }
+
+  .esri-catalog-layer-list__action-menu[open] .esri-catalog-layer-list__action-group {
+    display: flex;
+  }
+
+  .esri-catalog-layer-list__visible-icon {
+    visibility: hidden;
+  }
+
+  .esri-catalog-layer-list__item--active:hover,
+  .esri-catalog-layer-list__item--active:focus,
+  .esri-catalog-layer-list__item--active:focus-within {
+    > .esri-catalog-layer-list__visible-toggle > .esri-catalog-layer-list__visible-icon {
+      visibility: visible;
+    }
+  }
+
+  .esri-catalog-layer-list__item--invisible {
+    color: $interactive-font-color--disabled;
+  }
+
+  .esri-catalog-layer-list__status-indicator {
+    @include layerListStatusIndicator();
+  }
+
+  .esri-catalog-layer-list__publishing {
+    @include layerListPublishingIndicator();
+
+    transform-origin: var(--calcite-list-item-icon-center) var(--calcite-list-item-icon-center);
+    animation: esri-catalog-layer-list__publishing-anim 2s normal infinite;
+  }
+
+  .esri-catalog-layer-list__updating {
+    @include layerListUpdatingIndicator();
+
+    animation: esri-catalog-layer-list__updating-anim 2s normal infinite;
+  }
+
+  .esri-catalog-layer-list__connection-status {
+    @include layerListConnectionStatus();
+  }
+
+  .esri-catalog-layer-list__connection-status--connected {
+    color: $connection-connected;
+  }
+
+  .esri-catalog-layer-list__item-content {
+    @include layerListItemContent();
+  }
+
+  .esri-catalog-layer-list__item-content-bottom {
+    @include layerListContentBottom();
+  }
+
+  .esri-catalog-layer-list__item-content-bottom .esri-legend__service {
+    @include layerListLegend();
+  }
+
+  .esri-catalog-layer-list__item-message {
+    @include layerListContentBottom();
+  }
+
+  @keyframes esri-catalog-layer-list__updating-anim {
+    @include layerListUpdating();
+  }
+
+  @keyframes esri-catalog-layer-list__publishing-anim {
+    @include layerListPublishing();
+  }
+}
+
+@if $include_CatalogLayerList == true {
+  @include catalogLayerList();
+}

--- a/assets/esri/themes/base/widgets/_ColorPicker.scss
+++ b/assets/esri/themes/base/widgets/_ColorPicker.scss
@@ -49,24 +49,7 @@
     }
 
     &__popover {
-      @include defaultBoxShadow();
-
-      background: var(--calcite-color-foreground-1); //  match color picker background
-      width: 272px; // calcite-color-picker may not render immediately, so we make sure we have the right width right away.
-      max-height: 70vh;
-      overflow: hidden auto;
-    }
-
-    &__opacity-slider-container {
-      padding: $cap-spacing $side-spacing;
-    }
-
-    &__opacity-slider {
-      margin-inline: 8px; // Align slider handles
-    }
-
-    &__calcite-color-picker {
-      --calcite-color-border-1: transparent;
+      --calcite-color-border-1: none;
     }
   }
 }

--- a/assets/esri/themes/base/widgets/_CoordinateConversion.scss
+++ b/assets/esri/themes/base/widgets/_CoordinateConversion.scss
@@ -55,26 +55,6 @@
     background-color: $background-color--hover;
   }
 
-  .esri-coordinate-conversion__button {
-    border-color: $interactive-font-color;
-    background-color: $background-color;
-    width: auto;
-    min-width: 30%;
-    max-width: 50%;
-    color: $interactive-font-color;
-  }
-
-  .esri-coordinate-conversion__convert-button-span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .esri-coordinate-conversion__button:hover {
-    border-color: $interactive-font-color;
-    background-color: $interactive-font-color;
-    color: $background-color;
-  }
-
   .esri-coordinate-conversion__input-group {
     display: flex;
     align-items: center;
@@ -89,16 +69,10 @@
   }
 
   .esri-coordinate-conversion .esri-coordinate-conversion__input-coordinate[type="text"] {
+    flex: 1;
     margin: 0;
-    border: 1px solid $border-color;
-    padding: 0 0.5em;
-    width: 100%;
     height: 2em;
     font-size: $font-size--small;
-  }
-
-  .esri-coordinate-conversion__input-coordinate--rejected {
-    text-decoration: underline red;
   }
 
   .esri-coordinate-conversion__settings {
@@ -161,9 +135,7 @@
   }
 
   .esri-coordinate-conversion__pattern-input {
-    padding: 4px;
     width: 100%;
-    height: $button-height;
   }
 
   .esri-coordinate-conversion__tools {
@@ -173,21 +145,12 @@
     padding: 0;
   }
 
-  .esri-coordinate-conversion__select-primary {
-    margin: 0;
-    padding: 0 2.5em 0 0.5em;
-    width: auto;
-    font-size: inherit;
+  .esri-coordinate-conversion__select-row {
+    text-align-last: center;
   }
 
-  .esri-coordinate-conversion__select-row {
-    flex: 0 0 75px;
-    margin: 0;
-    background: $background-color;
-    padding: 0 0.5em;
-    height: 2em;
+  .esri-coordinate-conversion__input-select {
     text-align-last: center;
-    font-size: inherit;
   }
 
   .esri-coordinate-conversion__conversions-view {
@@ -232,16 +195,6 @@
 
     .esri-widget__heading {
       margin: 0 auto;
-    }
-
-    .esri-coordinate-conversion__back-button {
-      position: absolute;
-      margin-inline-start: 0;
-      background-color: $background-color--offset;
-
-      &:hover {
-        background-color: $background-color;
-      }
     }
   }
 

--- a/assets/esri/themes/base/widgets/_Daylight.scss
+++ b/assets/esri/themes/base/widgets/_Daylight.scss
@@ -36,19 +36,9 @@
       justify-content: space-between;
     }
 
-    .esri-date-picker,
+    &__date-picker,
     &__season-picker {
       flex-grow: 1;
-    }
-
-    .esri-date-picker__calendar-toggle {
-      height: 32px;
-      font-size: $font-size--small;
-    }
-
-    &__container--disabled .esri-date-picker {
-      opacity: $opacity--disabled;
-      pointer-events: none;
     }
 
     &__play-pause-button {
@@ -75,7 +65,7 @@
     }
 
     .esri-slider.esri-slider--horizontal {
-      z-index: 1;
+      z-index: 2; // Ensure the timezone popover stays on top of the date picker (which has a z-index=1) - #60677
 
       .esri-slider-with-dropdown__box {
         display: flex;
@@ -100,10 +90,6 @@
           list-style: none;
           line-height: 1em;
           font-variant-numeric: tabular-nums;
-        }
-
-        .esri-slider__tick-label {
-          line-height: 1em;
         }
 
         .esri-slider__label-input {

--- a/assets/esri/themes/base/widgets/_Directions.scss
+++ b/assets/esri/themes/base/widgets/_Directions.scss
@@ -10,6 +10,8 @@
   }
 
   .esri-directions__panel-content {
+    display: flex;
+    flex-flow: column;
     padding: $cap-spacing 0;
   }
 
@@ -33,10 +35,14 @@
   .esri-directions__travel-modes,
   .esri-directions__departure-time {
     display: flex;
-    flex-direction: column;
     align-items: center;
     padding-inline: $side-spacing;
-    width: 100%;
+  }
+
+  .esri-directions__travel-modes .esri-select,
+  .esri-directions__departure-time .esri-select {
+    flex: 1 0 auto;
+    width: auto;
   }
 
   .esri-directions__panel-content--sign-in,
@@ -87,7 +93,6 @@
 
     display: flex;
     flex-direction: column;
-    width: 100%;
   }
 
   .esri-directions__departure-date-time-pickers {
@@ -435,7 +440,6 @@
       align-items: center;
       margin-top: 12px;
       padding-inline: 15px;
-      width: 100%;
     }
 
     &__save-buttons,

--- a/assets/esri/themes/base/widgets/_Editor.scss
+++ b/assets/esri/themes/base/widgets/_Editor.scss
@@ -156,6 +156,7 @@
       flex-direction: row;
       border-bottom: var(--divider-border);
       background-color: var(--calcite-color-foreground-1);
+      overflow-wrap: anywhere;
     }
 
     &__settings {
@@ -171,6 +172,10 @@
 
     &__notice {
       margin-bottom: $cap-spacing;
+    }
+
+    .esri-snapping-controls__layer-list {
+      max-height: 220px;
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/assets/esri/themes/base/widgets/_ElevationProfile.scss
+++ b/assets/esri/themes/base/widgets/_ElevationProfile.scss
@@ -1,28 +1,22 @@
 @mixin elevationProfile() {
-  $width: 550px;
-  $chart-height: 180px;
-
-  $actions-spacing-h: $side-spacing--half;
-  $actions-spacing-v: $cap-spacing--half;
-
-  $statistics-font-size: $font-size--tiny;
-  $statistics-slope-values-spacing: $side-spacing--half;
-
-  $popover-padding: $cap-spacing $side-spacing;
-
   // ----------------------------------------------------------------------------
   // Widget
   // ----------------------------------------------------------------------------
 
   .esri-elevation-profile {
+    --popover-padding: #{$cap-spacing} #{$side-spacing};
+    --width: 550px;
+    --chart-height: 180px;
     --calcite-label-margin-bottom: 0;
+    --actions-spacing-h: #{$side-spacing--half};
+    --actions-spacing-v: #{$cap-spacing--half};
 
     position: relative;
     isolation: isolate;
     padding: var(--esri-widget-padding);
 
     &.esri-component.esri-widget--panel {
-      width: $width;
+      width: var(--width);
       max-width: 100%; // Don't overflow parent container, especially on mobile
     }
 
@@ -46,14 +40,16 @@
     }
 
     &__action-button {
-      margin-inline-start: $actions-spacing-h;
+      margin-inline-start: var(--actions-spacing-h);
       width: auto;
     }
 
     &__main-container {
+      display: flex;
       position: relative;
+      flex-flow: column;
       width: 100%;
-      height: $chart-height;
+      height: var(--chart-height);
     }
 
     &__chart-container {
@@ -63,13 +59,12 @@
     }
 
     &__prompt-container {
+      box-sizing: border-box;
       display: flex;
       align-items: center;
       justify-content: center;
       margin-bottom: 0;
       padding: $cap-spacing $side-spacing;
-      padding-top: $cap-spacing--double + $cap-spacing;
-      width: 100%;
       height: 100%;
       text-align: center;
 
@@ -122,7 +117,7 @@
       margin-inline-start: 0;
 
       &:not(:last-of-type) {
-        margin-bottom: $actions-spacing-v;
+        margin-bottom: var(--actions-spacing-v);
       }
     }
   }
@@ -136,7 +131,7 @@
       display: flex;
       flex-direction: column;
       gap: $cap-spacing;
-      padding: $popover-padding;
+      padding: var(--popover-padding);
       min-width: 180px; // Give some space for our labels to render properly
       color: $font-color;
       font-size: $font-size__body;
@@ -246,6 +241,11 @@
         height: 16px;
       }
     }
+  }
+
+  // Ensure the chart fits when the view is really small.
+  .esri-view-height-xsmall .esri-elevation-profile {
+    --chart-height: 68px;
   }
 
   .esri-elevation-profile--portrait {

--- a/assets/esri/themes/base/widgets/_Expand.scss
+++ b/assets/esri/themes/base/widgets/_Expand.scss
@@ -1,47 +1,62 @@
 @mixin expand() {
-  @include expandPanelOpen("esri-expand--drawer");
-  @include expandPanelClosed("esri-expand--floating");
-
   .esri-expand {
+    --esri-widget-panel-max-height: 95vh;
+    --calcite-sheet-max-height: var(--esri-widget-panel-max-height);
+    --calcite-sheet-height: auto;
+
     min-width: $button-width;
     min-height: $button-height;
-    overflow: visible;
   }
 
-  .esri-expand__container {
+  .esri-expand__toggle {
     position: relative;
-    transition: 300ms;
   }
 
-  .esri-expand__content {
-    @include defaultBoxShadow();
+  .esri-expand__popover-content {
+    display: flex;
+    flex-direction: column;
+  }
 
-    transition:
-      opacity 250ms ease-in-out,
-      margin 250ms ease-in-out;
-    visibility: hidden;
-    opacity: 0;
-    z-index: 1;
-    margin: 0 $side-spacing--quarter;
-    width: 0;
-    height: 0;
+  .esri-expand__popover-content .esri-widget--panel {
+    width: $panel-width;
+  }
+
+  .esri-expand__panel {
+    max-height: var(--esri-widget-panel-max-height);
+  }
+
+  .esri-expand__panel-content .esri-widget {
+    width: auto;
+  }
+
+  .esri-expand__panel-content .esri-widget--panel {
+    flex: 1 1 auto;
+  }
+
+  .esri-expand__popover-content,
+  .esri-expand__panel-content {
+    .esri-widget {
+      box-sizing: border-box;
+      box-shadow: none;
+    }
+  }
+
+  .esri-expand__panel-content,
+  .esri-expand__content-container {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: stretch;
+    background-color: var(--calcite-color-foreground-1);
+  }
+
+  .esri-expand__sheet .esri-expand__panel-content,
+  .esri-expand__sheet .esri-expand__content-container {
     overflow: hidden;
   }
 
-  :is(.esri-ui-top-left, .esri-ui-bottom-left) .esri-expand__content {
-    left: 100%;
-  }
-
-  :is(.esri-ui-top-right, .esri-ui-bottom-right) .esri-expand__content {
-    right: 100%;
-  }
-
-  :is(.esri-ui-top-left, .esri-ui-top-right) .esri-expand__content {
-    top: 0;
-  }
-
-  :is(.esri-ui-bottom-left, .esri-ui-bottom-right) .esri-expand__content {
-    bottom: 0;
+  .esri-expand__panel-icon-number {
+    align-self: center;
   }
 
   .esri-collapse__icon {
@@ -56,20 +71,6 @@
     transform: rotate(180deg);
   }
 
-  .esri-expand__content--expanded {
-    visibility: visible;
-    opacity: 1;
-    margin-right: $side-spacing--half;
-    margin-left: $side-spacing--half;
-    width: auto;
-    height: auto;
-    overflow: visible;
-  }
-
-  .esri-expand__content .esri-widget {
-    box-shadow: none;
-  }
-
   .esri-expand__icon-number {
     display: flex;
     position: absolute;
@@ -81,7 +82,6 @@
     background-color: $interactive-font-color;
     padding: 0.125em 0.333em;
     height: $button-height--half;
-    animation: expand-number-intro-ani 1000ms ease-in-out;
     line-height: 1em;
     color: $background-color;
     font-size: $font-size--small;
@@ -96,171 +96,35 @@
     left: $button-width--fifth * -1;
   }
 
-  :is(.esri-ui-bottom-right, .esri-ui-top-right, .esri-ui-bottom-left, .esri-ui-top-left)
-    .esri-expand__icon-number--expanded {
-    position: static;
-    top: auto;
-    right: auto;
-    left: auto;
-  }
-
-  .esri-expand__icon-number--expanded {
-    display: none;
-  }
-
   // Max heights
   .esri-view-height-greater-than-medium {
-    .esri-ui-corner .esri-component .esri-expand__content {
+    .esri-expand__popover-content .esri-widget--panel {
       max-height: $view-height--gt-medium__component-max-height;
     }
   }
 
   .esri-view-height-medium {
-    .esri-ui-corner .esri-component .esri-expand__content {
+    .esri-expand__popover-content .esri-widget--panel {
       max-height: $view-height--medium__component-max-height;
     }
   }
 
   .esri-view-height-small {
-    .esri-ui-corner .esri-component .esri-expand__content {
+    .esri-expand__popover-content .esri-widget--panel {
       max-height: $view-height--small__component-max-height;
     }
   }
 
   .esri-view-height-xsmall {
-    .esri-ui-corner .esri-component .esri-expand__content {
+    .esri-expand__popover-content .esri-widget--panel {
       max-height: $view-height--xsmall__component-max-height;
     }
   }
 
-  .esri-view-width-xsmall {
-    @include expandPanelOpen("esri-expand--auto");
-  }
-
-  .esri-view-width-greater-than-xsmall {
-    @include expandPanelClosed("esri-expand--auto");
-  }
-
-  @keyframes expand-slide-rtl-ani {
-    from {
-      right: -600px;
-    }
-
-    to {
-      right: 0;
-    }
-  }
-
-  @keyframes expand-slide-ltr-ani {
-    from {
-      left: -600px;
-    }
-
-    to {
-      left: 0;
-    }
-  }
-
-  @keyframes expand-number-intro-ani {
-    0% {
-      transform: scale(1);
-    }
-
-    50% {
-      transform: scale(1);
-    }
-
-    75% {
-      transform: scale(1.25);
-    }
-
-    100% {
-      transform: scale(1);
-    }
-  }
-}
-
-@mixin expandPanelOpen($modeClass) {
-  .#{$modeClass} {
-    .esri-widget {
-      width: 100%;
-      max-width: 100%;
-    }
-
-    .esri-expand__container--expanded {
-      position: fixed;
-      top: 0;
-      bottom: 0;
-      z-index: 1;
-      margin: 0;
-      background: $background-color;
-      height: 100%;
-      overflow: auto;
-
-      .esri-expand__panel {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 1.023rem;
-
-        .esri-expand__icon-number--expanded {
-          display: block;
-        }
-      }
-    }
-
-    .esri-expand__mask--expanded {
-      position: fixed;
-      inset: 0;
-      opacity: 0.8;
-      z-index: 1;
-      background-color: #000;
-      width: 100%;
-      height: 100%;
-    }
-  }
-
-  .esri-ui-top-right,
-  .esri-ui-bottom-right {
-    .#{$modeClass} {
-      .esri-expand__panel {
-        flex-flow: row nowrap;
-      }
-
-      .esri-expand__container--expanded {
-        width: 75%;
-        max-width: $panel-width;
-        animation: expand-slide-rtl-ani 300ms forwards;
-      }
-    }
-  }
-
-  .esri-ui-top-left,
-  .esri-ui-bottom-left {
-    #{$modeClass} {
-      .esri-expand__panel {
-        flex-flow: row-reverse nowrap;
-      }
-
-      .esri-expand__container--expanded {
-        width: 75%;
-        max-width: $panel-width;
-        animation: expand-slide-ltr-ani 300ms forwards;
-      }
-    }
-  }
-}
-
-@mixin expandPanelClosed($modeClass) {
-  .#{$modeClass} {
-    .esri-expand__content {
-      position: absolute;
-    }
-
-    .esri-expand__mask,
-    .esri-expand__content-panel {
-      display: none;
-    }
+  [class*="esri-view-height-"] .esri-expand__popover-content .esri-widget--panel .esri-widget--panel {
+    // When panel widgets are nested inside Expand.
+    width: unset;
+    max-height: unset;
   }
 }
 

--- a/assets/esri/themes/base/widgets/_FeatureForm.scss
+++ b/assets/esri/themes/base/widgets/_FeatureForm.scss
@@ -1,6 +1,7 @@
 @mixin featureForm() {
   $group-border-width: 3px;
   $panel-background-color: var(--calcite-color-background);
+  $text-element-line-height: 1.375;
 
   .esri-feature-form {
     background-color: $panel-background-color;
@@ -105,10 +106,6 @@
     font-weight: var(--calcite-font-weight-medium);
   }
 
-  .esri-feature-form__input--invalid {
-    border: 1px solid $border-color--error;
-  }
-
   .esri-feature-form__field-error-message {
     padding: $side-spacing--half 0;
     font-size: $font-size--small;
@@ -154,6 +151,113 @@
 
   .esri-feature-form__group--active {
     border-inline-start-color: $border-color--active;
+  }
+
+  .esri-feature-form__text-element {
+    line-height: $text-element-line-height;
+    color: var(--calcite-color-text-3);
+    font-size: var(--calcite-font-size--1);
+    font-weight: var(--calcite-font-weight-normal);
+
+    a {
+      display: inline;
+      position: relative;
+      transition:
+        background-color,
+        block-size,
+        border-color,
+        box-shadow,
+        color,
+        inset-block-end,
+        inset-block-start,
+        inset-inline-end,
+        inset-inline-start inset-size,
+        opacity,
+        outline-color,
+        transform var(--calcite-animation-timing) ease-in-out 0s,
+        outline 0s,
+        outline-offset 0s;
+      border-style: none;
+      background-color: transparent;
+      background-image: linear-gradient(currentColor, currentColor),
+        linear-gradient(var(--calcite-color-brand-underline), var(--calcite-color-brand-underline));
+      background-position-x: 0%, 100%;
+      background-position-y: min(1.5em, 100%);
+      background-repeat: no-repeat, no-repeat;
+      background-size:
+        0% 1px,
+        100% 1px;
+      padding: 0;
+      text-decoration: none;
+      color: var(--calcite-color-text-link);
+
+      &:hover,
+      &:focus {
+        background-size:
+          100% 1px,
+          100% 1px;
+      }
+
+      &:active {
+        background-size:
+          100% 2px,
+          100% 2px;
+      }
+
+      &.calcite--rtl {
+        background-position:
+          100% 100%,
+          100% 100%;
+      }
+    }
+
+    code {
+      border: 1px solid var(--calcite-color-border-3);
+      border-radius: $border-radius;
+      background-color: var(--calcite-color-foreground-3);
+      padding: 0.25em;
+      white-space: normal;
+      word-break: break-word;
+      color: var(--calcite-color-text-2);
+      font-family: var(--calcite-code-family);
+      font-size: 85%;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      margin-bottom: 4px;
+      line-height: $text-element-line-height;
+      color: var(--calcite-color-text-1);
+      font-size: var(--calcite-font-size-0);
+      font-weight: var(--calcite-font-weight-bold);
+    }
+
+    h5 {
+      font-weight: var(--calcite-font-weight-medium);
+    }
+
+    h6 {
+      margin-bottom: 4px;
+      line-height: $text-element-line-height;
+      color: var(--calcite-color-text-2);
+      font-size: var(--calcite-font-size--1);
+      font-weight: var(--calcite-font-weight-medium);
+    }
+
+    p {
+      margin-bottom: 16px;
+      line-height: $text-element-line-height;
+      color: var(--calcite-color-text-3);
+      font-size: var(--calcite-font-size--1);
+      font-weight: var(--calcite-font-weight-normal);
+    }
+
+    strong {
+      font-weight: var(--calcite-font-weight-bold);
+    }
   }
 
   [dir="rtl"] {

--- a/assets/esri/themes/base/widgets/_FeatureTable.scss
+++ b/assets/esri/themes/base/widgets/_FeatureTable.scss
@@ -53,70 +53,103 @@
     width: 100%;
     height: 100%;
 
-    .esri-feature-table__content {
+    &__content {
+      overflow: hidden;
+    }
+
+    &__collapsed {
+      min-width: 500px;
+
+      &:not(:last-child) {
+        border-inline-end: 1px solid var(--calcite-color-text-2);
+        min-width: 300px;
+        max-width: 300px;
+      }
+    }
+
+    &__expanded {
+      display: flex;
+      min-width: 300px;
+
+      &:not(:last-child) {
+        border-inline-end: 1px solid var(--calcite-color-text-2);
+      }
+    }
+
+    &__table-container {
+      display: flex;
       flex: 1 1 0;
-      flex-grow: 1;
       margin: 0;
       padding: 0;
       min-height: 0;
-    }
 
-    .esri-grid--no-column-menu {
-      .esri-column__menu-container {
-        display: none;
+      calcite-panel div {
+        display: flex;
+        flex: 1 1 0;
+        flex-direction: row;
       }
     }
 
-    .esri-grid__grid {
+    &__table-navigation {
+      --calcite-label-margin-bottom: 0;
+
+      display: flex;
+      align-items: center;
+      background-color: var(--calcite-ui-foreground-1);
+      padding-block-start: 2px; // Height of calcite progress component
       width: 100%;
-      height: 100%;
 
-      .esri-column__menu-container.esri-button-menu {
-        position: inherit;
+      // Flips the 'move-up' icon; inspired by similar update in Popup
+      calcite-action:first-child {
+        transform: scaleX(-1);
+      }
+
+      calcite-action {
+        display: flex;
+        overflow: hidden;
+      }
+
+      :last-child {
+        display: flex;
+        float: inline-end;
+        margin-inline: auto $side-spacing--half;
       }
     }
 
-    .esri-grid,
-    .esri-feature-table__menu,
-    .esri-column__menu-container,
-    .esri-button-menu,
-    .esri-button-menu__button {
+    &__menu-popover {
+      @include defaultBoxShadow();
+
+      // Avoid issues with menu growing outside of the viewport
+      // 256px is roughly the height of a filter and 5 menu items.
+      max-width: 300px;
+      max-height: 256px;
+      overflow-y: auto;
+    }
+
+    .esri-grid {
       background-color: inherit;
+
+      &__grid {
+        width: 100%;
+        height: 100%;
+      }
     }
 
     vaadin-grid {
+      border-bottom: none;
+      border-inline: none;
       background-color: inherit;
       color: inherit;
       font-family: inherit;
       font-size: $font-size;
     }
 
-    // Explicit value required to avoid transparent body cells behind frozen columns.
-    vaadin-grid::part(row) {
-      background-color: $background-color;
-    }
-
-    // #58067 - Workaround to support changing background color of the entire row on hover.
-    // Does not apply to the selection column due to transparency issues but hovering
-    // over a selection cell will highlight the entire row. Applies to any 'frozen' columns.
-    vaadin-grid::part(row):hover {
-      --row-background-color: var(--calcite-color-background);
-    }
-
     vaadin-grid::part(body-cell) {
-      background-color: var(--row-background-color);
       font-size: $font-size;
 
       &:hover {
-        background-color: var(--row-background-color);
+        background-color: var(--calcite-color-foreground-2);
       }
-    }
-
-    // Required to avoid transparent body cells behind frozen columns.
-    // Must be defined *after* body-cell has a background-color applied.
-    vaadin-grid::part(body-cell frozen-cell),
-    vaadin-grid::part(body-cell frozen-to-end-cell) {
-      background-color: inherit;
     }
 
     vaadin-grid::part(header-cell) {
@@ -129,166 +162,13 @@
     }
 
     vaadin-grid::part(body-cell invalid) {
-      color: var(--calcite-color-border-3);
+      color: var(--calcite-color-text-3);
       font-style: italic;
     }
-  }
 
-  .esri-feature-table__menu {
-    order: 3;
-    padding: 4px;
-    width: 40px;
-    height: 40px;
-
-    .esri-button-menu {
-      position: relative;
-      bottom: auto;
+    vaadin-grid::part(body-cell highlight) {
+      background-color: var(--calcite-color-foreground-3);
     }
-
-    .esri-button-menu__content {
-      max-width: 600px;
-    }
-  }
-
-  .esri-feature-table__header {
-    display: flex;
-    flex-direction: row;
-    margin: 0;
-    width: 100%;
-    height: 40px;
-    line-height: 40px;
-    font-weight: $font-weight;
-  }
-
-  .esri-feature-table__title {
-    flex-grow: 1;
-    order: 2;
-  }
-
-  .esri-feature-table__loader-container {
-    order: 1;
-    margin: 0 8px;
-    width: 32px;
-    height: 40px;
-  }
-
-  .esri-feature-table__loader {
-    background: url("../base/images/loading-throb.gif") no-repeat center;
-    width: 32px;
-    height: 40px;
-  }
-
-  .esri-field-column__header-root {
-    display: flex;
-    flex-grow: 1;
-    align-items: center;
-
-    &--editable {
-      .esri-field-column__header-content {
-        .esri-icon-locked {
-          display: flex;
-        }
-      }
-    }
-
-    .esri-icon-locked {
-      display: none;
-    }
-
-    &--menu-enabled {
-      .esri-column__menu-container.esri-button-menu {
-        display: flex;
-      }
-    }
-
-    .esri-column__menu-container {
-      display: none;
-    }
-  }
-
-  .esri-field-column__header-content {
-    align-items: center;
-    min-height: 28px;
-  }
-
-  .esri-field-column__header-content,
-  .esri-field-column__header-label {
-    display: flex;
-    flex-grow: 1;
-    overflow: hidden;
-  }
-
-  .esri-field-column__cell-content {
-    font-size: 0.9em;
-  }
-
-  .esri-field-column__button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 125ms ease-in-out;
-    border: none;
-    background-color: transparent;
-    width: 26px;
-    height: auto;
-    text-align: center;
-    color: $button-color;
-    font-size: $icon-size;
-
-    &:disabled {
-      cursor: default;
-      color: $interactive-font-color--disabled;
-    }
-
-    &:hover,
-    &:focus {
-      background-color: $background-color--hover;
-      cursor: pointer;
-      color: $interactive-font-color--hover;
-    }
-  }
-
-  .esri-field-column__cell__input-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-
-    input,
-    select {
-      position: absolute;
-      top: 0;
-      left: 0;
-      padding: 0;
-    }
-
-    div,
-    input,
-    select {
-      display: flex;
-      width: 100%;
-    }
-
-    calcite-action-bar {
-      background-color: transparent;
-    }
-
-    div:first-child {
-      flex-direction: column;
-    }
-
-    calcite-input-time-picker:last-child,
-    calcite-input-time-picker:nth-child(2),
-    calcite-input-time-zone {
-      margin-top: -1px;
-    }
-  }
-
-  .esri-field-column__cell-input {
-    flex: 1 1 0;
-    border: none;
-    width: 100%;
-    height: 100%;
   }
 
   .esri-feature-table__prompt--info {
@@ -303,11 +183,14 @@
     @include esri-feature-table__prompt(var(--calcite-color-status-danger));
   }
 
-  [dir="rtl"] {
-    .esri-feature-table__menu-content {
-      right: auto;
-      left: 2px;
-    }
+  .esri-feature-table__layer-switcher-menu {
+    display: flex;
+    align-items: center;
+  }
+
+  .esri-column__show-related-records-button {
+    display: flex;
+    height: 100%;
   }
 }
 

--- a/assets/esri/themes/base/widgets/_Grid.scss
+++ b/assets/esri/themes/base/widgets/_Grid.scss
@@ -43,6 +43,10 @@
       }
     }
 
+    .esri-column__sorter:hover {
+      cursor: pointer;
+    }
+
     .esri-column__sorter,
     .esri-column__header-label {
       display: flex;
@@ -54,6 +58,7 @@
     }
 
     .esri-column__header-label span {
+      flex-grow: 1;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -61,8 +66,110 @@
 
     .esri-column__header-content {
       display: flex;
-      flex-grow: 1;
+      float: inline-start;
       align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+
+      calcite-icon {
+        float: inline-start;
+        margin-inline-end: 2px;
+        height: 100%;
+      }
+
+      calcite-dropdown {
+        float: inline-end;
+        max-height: 180px;
+
+        // Avoid issues with menu growing outside of the viewport
+        calcite-dropdown-group {
+          max-width: 200px;
+          overflow-x: auto;
+
+          &:only-of-type {
+            max-height: 180px;
+            overflow: visible;
+          }
+        }
+
+        &[open] {
+          calcite-dropdown-item {
+            display: flex;
+          }
+        }
+
+        calcite-action {
+          --calcite-color-foreground-1: transparent;
+        }
+
+        // Prevents frozen columns from appearing offset from the table edge on load.
+        // This is because VaadinGrid's positioning logic accounts for 'hidden' calcite dropdown items,
+        // since they use 'visibility: hidden' instead of 'display: none'.
+        calcite-dropdown-item,
+        calcite-dropdown-item[hidden] {
+          display: none;
+        }
+      }
+    }
+  }
+
+  .esri-column__action {
+    --calcite-color-foreground-1: transparent;
+  }
+
+  .esri-column__header-menu-icon {
+    margin-inline-end: $side-spacing;
+  }
+
+  .esri-column__cell-input {
+    flex: 1 1 0;
+    border: none;
+    width: 100%;
+    height: 100%;
+  }
+
+  .esri-column__cell__input-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+
+    input,
+    select {
+      position: absolute;
+      top: 0;
+      left: 0;
+      padding: 0;
+    }
+
+    div,
+    input,
+    select {
+      display: flex;
+      width: 100%;
+    }
+
+    calcite-action-bar {
+      background-color: transparent;
+    }
+
+    div:first-child {
+      flex-direction: column;
+    }
+
+    calcite-input-time-zone {
+      --calcite-dropdown-width: 200px;
+    }
+
+    // Remove top border between stacked components for cleaner look.
+    // Only remove border on TimePicker when it's not the only visible component (2nd or last).
+    // Always remove the top border from TimeZone component (always displayed last)
+    calcite-input-time-picker:last-child,
+    calcite-input-time-picker:nth-child(2),
+    calcite-input-time-zone {
+      margin-top: -1px;
     }
   }
 }

--- a/assets/esri/themes/base/widgets/_ItemList.scss
+++ b/assets/esri/themes/base/widgets/_ItemList.scss
@@ -47,7 +47,9 @@
   }
 
   .esri-item-list__list-item-icon {
+    place-content: center;
     margin-inline: 0.75rem; // Matches default spacing used by Calcite
+    height: $list-item-height;
   }
 
   .esri-item-list__no-matches-message {

--- a/assets/esri/themes/base/widgets/_LayerList.scss
+++ b/assets/esri/themes/base/widgets/_LayerList.scss
@@ -9,10 +9,28 @@
 
   .esri-layer-list__item {
     --calcite-list-item-spacing-indent: 2rem;
+    --calcite-list-item-icon-center: 8.5px;
   }
 
   .esri-layer-list__item-temporary-icon {
     margin-inline-start: 0.25rem;
+  }
+
+  .esri-layer-list__item-table-icon,
+  .esri-layer-list__item-catalog-icon {
+    margin-inline-end: 0;
+  }
+
+  .esri-layer-list__item-action-image {
+    @include layerListActionImage();
+  }
+
+  .esri-layer-list__action-menu .esri-layer-list__action-group {
+    display: none;
+  }
+
+  .esri-layer-list__action-menu[open] .esri-layer-list__action-group {
+    display: flex;
   }
 
   .esri-layer-list__visible-icon {
@@ -27,7 +45,7 @@
     }
   }
 
-  .esri-layer-list__item--invisible-at-scale {
+  .esri-layer-list__item--invisible {
     color: $interactive-font-color--disabled;
   }
 
@@ -38,6 +56,7 @@
   .esri-layer-list__publishing {
     @include layerListPublishingIndicator();
 
+    transform-origin: var(--calcite-list-item-icon-center) var(--calcite-list-item-icon-center);
     animation: esri-layer-list__publishing-anim 2s normal infinite;
   }
 

--- a/assets/esri/themes/base/widgets/_Popup.scss
+++ b/assets/esri/themes/base/widgets/_Popup.scss
@@ -49,6 +49,10 @@
         margin: 0;
       }
     }
+
+    .esri-popup--hidden {
+      display: none;
+    }
   }
 
   .esri-popup--shadow {

--- a/assets/esri/themes/base/widgets/_Print.scss
+++ b/assets/esri/themes/base/widgets/_Print.scss
@@ -1,7 +1,10 @@
 @mixin print() {
   .esri-print {
+    display: flex;
     position: relative;
-    padding: $cap-spacing $side-spacing;
+    flex-grow: 1;
+    padding: 0;
+    min-height: $panel-min-height--large !important;
     overflow-y: auto;
 
     section[aria-hidden="true"] {
@@ -9,18 +12,40 @@
     }
   }
 
+  .esri-print__panel-items--centered {
+    display: flex;
+    align-items: center;
+  }
+
   .esri-print__header-title {
     margin: 0 auto 0 0;
-    padding: 0 0 $cap-spacing;
+    padding: $cap-spacing $side-spacing;
     font-size: $font-size__header-text;
     font-weight: $font-weight--bold;
   }
 
+  .esri-print__browse-template-button-container {
+    padding: $cap-spacing $side-spacing;
+  }
+
+  .esri-print__container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  .esri-print__content {
+    display: flex;
+    flex-flow: column;
+    flex-grow: 1;
+    justify-content: space-between;
+    background-color: $background-color;
+  }
+
   .esri-print__layout-section,
   .esri-print__map-only-section {
-    margin-bottom: $cap-spacing;
-    border-top: 1px solid $border-color;
-    padding: $cap-spacing 0 0;
+    margin-bottom: $cap-spacing--quarter;
+    padding: $cap-spacing $side-spacing;
   }
 
   .esri-print__layout-tab-list {
@@ -29,11 +54,14 @@
     bottom: -1px;
     justify-content: space-between;
     margin: 0;
+    background-color: $background-color--offset;
     padding: 0;
   }
 
   .esri-print__layout-tab {
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin: 0;
     border: 1px solid rgb(0 0 0 / 0%);
     cursor: pointer;
@@ -45,7 +73,6 @@
 
   .esri-print__layout-tab:hover,
   .esri-print__layout-tab:focus {
-    border-bottom: 1px solid $border-color;
     background-color: $background-color--hover;
     color: $font-color;
   }
@@ -53,6 +80,7 @@
   .esri-print__layout-tab[aria-selected="true"],
   .esri-print__layout-tab[aria-selected="true"]:hover {
     border-color: $border-color;
+    border-top-color: $border-color--active;
     border-bottom-color: $background-color;
     background-color: $background-color;
     color: $font-color;
@@ -63,17 +91,81 @@
   }
 
   .esri-print__panel-container {
+    display: flex;
     flex: 1 0;
+    flex-direction: column;
+    gap: $cap-spacing--three-quarters;
   }
 
-  .esri-print__input-text {
+  .esri-print__form-checkbox-label {
+    display: flex;
+    column-gap: $side-spacing--half;
+    align-items: center;
+  }
+
+  .esri-print__form-checkbox-label [type="checkbox"] {
     margin: 0;
-    width: 100%;
+  }
+
+  .esri-print__scale-info-container .esri-print__form-checkbox-label {
+    margin-block-end: $cap-spacing--half;
   }
 
   .esri-print__scale-input-container {
     display: flex;
     align-items: center;
+    padding-bottom: $cap-spacing;
+
+    .esri-print__scale-input {
+      flex-grow: 1;
+    }
+  }
+
+  .esri-print__template-select-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid $border-color;
+    cursor: pointer;
+
+    .esri-print__template-select-block {
+      flex-shrink: 1;
+      border: none;
+    }
+
+    .esri-print__template-select-icon {
+      @include icomoonIconSelector() {
+        background: transparent;
+      }
+
+      padding: $cap-spacing;
+    }
+  }
+
+  .esri-print__template-select-flow-item-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: space-between;
+    overflow-y: hidden;
+
+    .esri-print__template-select-flow-item-content {
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+
+      .esri-print__template-select-flow-item-list-heading {
+        display: flex;
+        gap: $side-spacing--half;
+        align-items: center;
+        border-bottom: 1px solid var(--calcite-color-border-3);
+        background-color: $background-color--offset;
+        padding: $cap-spacing $side-spacing;
+        color: $font-color;
+        font-size: $font-size;
+        font-weight: $font-weight--medium;
+      }
+    }
   }
 
   .esri-print__advanced-options-section {
@@ -81,18 +173,17 @@
       background: transparent;
     }
 
+    border: 1px solid $border-color;
     background-color: $background-color--offset;
-    color: $interactive-font-color;
   }
 
   .esri-print__advanced-options-button-container {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     background-color: transparent;
     width: 100%;
     overflow: visible;
-    color: $interactive-font-color;
   }
 
   .esri-print__advanced-options-button {
@@ -132,36 +223,30 @@
   .esri-print__size-container {
     @include icomoonIconSelector() {
       align-self: flex-end;
+      margin-bottom: $cap-spacing;
       background: transparent;
     }
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 15px;
-  }
-
-  .esri-print__size-container button {
-    color: $interactive-font-color;
-  }
-
-  .esri-print__width-container,
-  .esri-print__height-container {
-    flex: 0 0 43%;
+    display: inline-grid;
+    grid-template-columns: 1fr 1fr $button-width;
+    column-gap: $side-spacing--half;
+    width: 100%;
   }
 
   .esri-print__swap-button {
-    flex: 0 0 5%;
+    flex: 1 0 auto;
     border: none;
-  }
-
-  .esri-print__refresh-button {
-    border: 1px solid $border-color;
-    border-left-width: 0;
+    color: $interactive-font-color;
   }
 
   .esri-print__export-button {
-    margin: $cap-spacing--half 0;
+    margin: $cap-spacing--half $side-spacing--half;
+    width: auto;
+    min-height: unset;
+  }
+
+  .esri-print__export-section--centered {
+    text-align: center;
   }
 
   .esri-print__export-panel-container {
@@ -170,7 +255,6 @@
       margin-right: 0.5em;
     }
 
-    border-top: 1px solid #ddd;
     padding: $cap-spacing 0;
     font-size: $font-size--small;
   }
@@ -191,6 +275,11 @@
     }
   }
 
+  .esri-print__exported-file--loader {
+    align-self: center;
+    margin-inline: $cap-spacing;
+  }
+
   .esri-print__exported-file--error {
     cursor: pointer;
     color: $font-color--error;
@@ -198,6 +287,22 @@
 
   .esri-print .esri-print__exported-file--error:hover {
     color: $font-color--error;
+  }
+
+  .esri-print__exported-files-empty {
+    display: flex;
+    flex-direction: column;
+    gap: $cap-spacing;
+    align-items: center;
+    padding: $cap-spacing $side-spacing;
+  }
+
+  .esri-print__template-button-container {
+    padding: $cap-spacing $side-spacing;
+  }
+
+  .esri-print__template-done-button {
+    width: 100%;
   }
 
   .esri-print__loader {
@@ -208,11 +313,6 @@
   }
 
   [dir="rtl"] {
-    .esri-print__refresh-button {
-      border-right-width: 0;
-      border-left-width: 1px;
-    }
-
     .esri-print__export-panel-container {
       @include icomoonIconSelector() {
         margin-right: 0;

--- a/assets/esri/themes/base/widgets/_ScaleBar.scss
+++ b/assets/esri/themes/base/widgets/_ScaleBar.scss
@@ -12,6 +12,8 @@
 
   $offset_for_unit_label: 2ch;
 
+  $text-shadow-size: 1px;
+
   $border_style: $line_thickness solid $dark_color;
 
   .esri-scale-bar.esri-widget {
@@ -129,9 +131,12 @@
     .esri-scale-bar__label {
       padding: $cap-spacing--half 0 0;
       text-shadow:
-        0 0 1px $light_color,
-        0 0 1px $light_color,
-        0 0 1px $light_color;
+        $text-shadow-size 0 0 $light_color,
+        0 $text-shadow-size 0 $light_color,
+        $text-shadow-size $text-shadow-size 0 $light_color,
+        ($text-shadow-size * -1) 0 0 $light_color,
+        0 ($text-shadow-size * -1) 0 $light_color,
+        ($text-shadow-size * -1) ($text-shadow-size * -1) 0 $light_color;
     }
   }
 

--- a/assets/esri/themes/base/widgets/_ShadowCast.scss
+++ b/assets/esri/themes/base/widgets/_ShadowCast.scss
@@ -41,7 +41,7 @@
       margin-top: $cap-spacing;
     }
 
-    &__date-picker-container .esri-date-picker {
+    &__date-picker {
       display: block;
       flex-grow: 1;
     }
@@ -88,6 +88,10 @@
 
     &__threshold-config {
       .esri-slider {
+        // Ensure the timezone popover stays on top of the date picker (which has a z-index=1)
+        // See #60677, #61515
+        z-index: 2;
+
         // Fit slider content since default API slider doesn't do it for us.
         padding-top: $slider-thumb-size;
         padding-bottom: 25px;

--- a/assets/esri/themes/base/widgets/_Sketch.scss
+++ b/assets/esri/themes/base/widgets/_Sketch.scss
@@ -48,7 +48,20 @@
     display: flex;
     flex: 1 1 auto;
     flex-flow: column;
-    margin: $cap-spacing--half;
+    padding: $cap-spacing--half;
+    min-height: calc(100px - $cap-spacing);
+    max-height: $view-height--medium__component-max-height;
+    overflow-y: auto;
+  }
+
+  .esri-view-height-xsmall .esri-sketch__menu-container {
+    min-height: calc(100% - $cap-spacing);
+    max-height: $view-height--xsmall__component-max-height;
+  }
+
+  .esri-view-height-small .esri-sketch__menu-container {
+    min-height: calc(100% - $cap-spacing);
+    max-height: $view-height--small__component-max-height;
   }
 
   .esri-sketch__section {
@@ -109,6 +122,13 @@
     }
   }
 
+  .esri-sketch--horizontal {
+    .esri-sketch__info-panel {
+      width: min-content;
+      min-width: 100%;
+    }
+  }
+
   .esri-sketch--vertical {
     flex-flow: row-reverse;
 
@@ -134,6 +154,9 @@
     }
 
     .esri-sketch__info-panel {
+      width: max-content;
+      max-width: 350px;
+
       &:empty {
         padding: 0;
       }

--- a/assets/esri/themes/base/widgets/_SketchTooltipControls.scss
+++ b/assets/esri/themes/base/widgets/_SketchTooltipControls.scss
@@ -2,6 +2,7 @@
   .esri-sketch-tooltip-controls {
     display: flex;
     flex-flow: column wrap;
+    min-width: 100%;
 
     &__block {
       margin: 0;

--- a/assets/esri/themes/base/widgets/_Slider.scss
+++ b/assets/esri/themes/base/widgets/_Slider.scss
@@ -256,6 +256,7 @@
   }
 
   .esri-slider__thumb {
+    box-sizing: border-box;
     position: absolute;
     top: -$slider-thumb-offset;
     left: -$slider-thumb-offset;

--- a/assets/esri/themes/base/widgets/_SnappingControls.scss
+++ b/assets/esri/themes/base/widgets/_SnappingControls.scss
@@ -3,14 +3,15 @@
 
   .esri-snapping-controls__toggle-block {
     margin: 0;
+    min-width: 100%;
   }
 
   .esri-snapping-controls__layer-list-block {
     border-bottom: none;
+    min-width: $panel-width--three-quarters;
   }
 
   .esri-snapping-controls__layer-list {
-    max-height: 220px;
     overflow: auto;
 
     &__filter {
@@ -27,6 +28,11 @@
         calcite-icon {
           margin-inline-start: 0;
         }
+      }
+
+      calcite-checkbox {
+        margin-left: 1rem;
+        padding-left: 2px;
       }
 
       calcite-icon {
@@ -125,11 +131,6 @@
         height: $toggle-handle-size;
         content: "";
       }
-    }
-
-    &.esri-disabled-element {
-      opacity: $opacity--disabled;
-      pointer-events: none;
     }
   }
 

--- a/assets/esri/themes/base/widgets/_TableList.scss
+++ b/assets/esri/themes/base/widgets/_TableList.scss
@@ -11,6 +11,18 @@
     @include layerListStatusIndicator();
   }
 
+  .esri-table-list__item-action-image {
+    @include layerListActionImage();
+  }
+
+  .esri-table-list__action-menu .esri-table-list__action-group {
+    display: none;
+  }
+
+  .esri-table-list__action-menu[open] .esri-table-list__action-group {
+    display: flex;
+  }
+
   .esri-table-list__publishing {
     @include layerListPublishingIndicator();
 

--- a/assets/esri/themes/base/widgets/_Tooltip.scss
+++ b/assets/esri/themes/base/widgets/_Tooltip.scss
@@ -2,18 +2,26 @@
 
 @mixin tooltip() {
   .esri-tooltip {
-    --field-height: 14px;
-    --field-height--input: 24px;
+    // Calcite variables
+    --calcite-input-padding-inline: 0.5rem;
+    --calcite-input-height: 1.5rem;
+
+    // Tooltip variables
+    --field-height: 0.875rem;
+    --field-height--input: var(--calcite-input-height);
     --field-row-gap: 1px;
-    --field-column-gap: #{$side-spacing};
+    --field-column-gap: var(--calcite-app-spacing-2);
+    --field-input-width: 6.5rem;
+    --field-title-extra-margin: var(--calcite-app-spacing-6);
+    --field-title-color: var(--calcite-color-text-2);
+    --field-value-color: var(--calcite-color-text-1);
     --font-size: var(--calcite-font-size--3);
     --font-size--input: var(--calcite-font-size--2);
-    --header-height: 24px;
-    --content-padding-inline: #{$side-spacing--half};
-    --content-padding-block: #{$cap-spacing--half};
-    --content-gap: var(--content-padding-block);
-    --help-message-border-spacing: #{$cap-spacing--half};
-    --suffix-width: 10px;
+    --content-padding-inline: var(--calcite-app-spacing-2);
+    --content-padding-block: var(--calcite-app-spacing-2);
+    --help-message-border-spacing: var(--calcite-app-spacing-2);
+    --help-message-min-width: 7rem;
+    --icon-size--feedback: 0.625rem; // Shrink icon to keep tooltip more compact in feedback mode
 
     position: absolute;
     top: 0;
@@ -23,21 +31,25 @@
     overflow: visible;
 
     &-content {
-      view-transition-name: tooltip-content;
       display: flex;
       position: relative;
       flex-direction: column;
-      gap: var(--content-gap);
-      border: solid 1 var(--calcite-color-border-3);
-      border-radius: 3px;
-      box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
-      background: var(--calcite-color-foreground-1);
+      gap: var(--content-padding-block);
+      border: solid 1px var(--calcite-color-border-3);
+      border-radius: 0.25rem; // Same as <calcite-popover>
+      box-shadow:
+        0 6px 20px -4px rgb(0 0 0 / 10%),
+        0 4px 12px -2px rgb(0 0 0 / 8%); // Same as <calcite-alert>
+
+      backdrop-filter: blur(4px);
+      background: rgb(255 255 255 / 80%);
       padding-block: var(--content-padding-block);
       padding-inline: var(--content-padding-inline);
       width: min-content;
       line-height: 1.1em;
       color: $font-color;
       font-size: var(--font-size);
+      view-transition-name: tooltip-content;
 
       // Hide the content altogether when there is nothing inside. Otherwise we'd
       // see a small empty square due to the tooltip padding.
@@ -52,7 +64,6 @@
         margin-inline: calc(var(--content-padding-inline) * -1); // Fill the whole width
         border-block-end: solid 1px var(--calcite-color-border-3);
         padding-block-end: 0;
-        height: var(--header-height);
 
         &__spacer {
           flex-grow: 1;
@@ -62,6 +73,7 @@
         &__actions {
           flex-grow: 0;
           flex-shrink: 0;
+          padding-inline-end: var(--content-padding-inline);
         }
       }
 
@@ -69,19 +81,26 @@
       &--input {
         --field-height: var(--field-height--input);
 
+        background: var(--calcite-color-foreground-1);
         pointer-events: all;
+        backdrop-filter: none;
       }
+    }
+
+    &.calcite-mode-dark &-content {
+      background: rgb(0 0 0 / 80%);
     }
 
     &-table {
       display: grid;
-      grid-template-columns: min-content 1fr;
+      grid-template-columns: max-content 1fr max-content max-content; // 4 columns: label, input/value, unit/suffix, lock icon.
       grid-gap: var(--field-row-gap) var(--field-column-gap);
-      width: 100%;
+      align-items: center;
+      width: max-content;
     }
 
-    &-field,
-    &-editable-field {
+    // Older fields, which are not editable and just display a title and a value.
+    &-field {
       display: contents;
 
       &__title,
@@ -91,36 +110,75 @@
         justify-content: flex-start;
         block-size: var(--field-height);
         white-space: nowrap;
+        color: var(--calcite-color-text-3);
+      }
+
+      &__title {
+        margin-inline-end: var(--field-title-extra-margin);
+        color: var(--field-title-color);
+      }
+
+      &__value {
+        grid-column: span 3;
+        color: var(--field-value-color);
+      }
+    }
+
+    &-editable-field {
+      display: contents;
+
+      &__title,
+      &__value {
+        align-items: center;
+        justify-content: flex-start;
+        block-size: var(--field-height);
+        white-space: nowrap;
+      }
+
+      &__title {
+        display: flex;
+      }
+
+      &__value {
+        display: contents;
+        font-variant-numeric: tabular-nums; // Make numbers look nice as they change
 
         &__content {
           display: flex;
-          gap: $side-spacing--eighth;
+          grid-column: span 3;
           align-items: center;
+          min-width: max-content;
 
           &--read-only {
-            // Match calcite-input's internal spacing
-            padding-inline: 0.5rem;
-            block-size: 1.5rem;
-            line-height: 1.5rem;
+            padding-inline: var(--calcite-input-padding-inline);
+            block-size: var(--calcite-input-height);
+            line-height: var(--calcite-input-height);
             font-size: var(--calcite-font-size--2);
           }
         }
       }
 
-      &__title {
-        // Shrink icon to keep tooltip more compact in feedback mode
-        --icon-size: 10px;
-
-        calcite-icon {
-          width: var(--icon-size);
-          min-width: var(--icon-size);
-          height: var(--icon-size);
-        }
+      &--feedback#{&}--locked &__value__content {
+        // When en editable field is locked in feedback mode, the value content can only span 2 columns,
+        // because the lock icon takes up the last column.
+        grid-column: span 2;
       }
 
-      &__value {
-        // Make numbers look nice as they change. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
-        font-variant-numeric: tabular-nums;
+      &--feedback &__title {
+        margin-inline-end: var(--field-title-extra-margin);
+        color: var(--field-title-color);
+      }
+
+      &--feedback &__value__content {
+        color: var(--field-value-color);
+      }
+
+      &--feedback &__lock-icon {
+        margin-top: -2px; // Visually align the icon with the text.
+        width: var(--icon-size--feedback);
+        min-width: var(--icon-size--feedback);
+        height: var(--icon-size--feedback);
+        min-height: var(--icon-size--feedback);
       }
 
       &--input {
@@ -132,11 +190,7 @@
       }
 
       &__input {
-        inline-size: 70px;
-      }
-
-      &__input-suffix {
-        min-width: var(--suffix-width);
+        inline-size: var(--field-input-width);
       }
 
       &__button {
@@ -152,19 +206,34 @@
     }
 
     &-help-message {
+      display: flex;
+      gap: var(--calcite-app-spacing-2);
+      align-items: center;
+      justify-content: center;
       margin-inline: calc(var(--content-padding-inline) * -1); // Fill the whole
       border-block-start: solid 1px var(--calcite-color-border-3);
-      padding-block-start: calc(var(--help-message-border-spacing) + var(--field-row-gap));
+      border-block-end: solid 1px transparent; // Compensate for the top border, so everything aligns nicely.
+      padding-block-start: var(--content-padding-inline);
       padding-inline: var(--content-padding-inline); // Add back the content padding, because we apply a negative margin
       width: auto;
-      min-width: 60px;
-      text-align: center;
+      min-width: var(--help-message-min-width);
+      text-align: left;
+      text-wrap: balance;
       white-space: break-spaces;
       font-size: var(--font-size);
 
       &:only-child {
         border-block-start: none;
+        border-block-end: none;
         padding-block-start: var(--field-row-gap);
+      }
+
+      &__icon {
+        color: var(--calcite-color-status-info);
+      }
+
+      &__text {
+        padding-block-start: 2px; // Visually align the text with the icon, because the baseline of the text is off.
       }
     }
   }

--- a/assets/esri/themes/base/widgets/_VideoPlayer.scss
+++ b/assets/esri/themes/base/widgets/_VideoPlayer.scss
@@ -1,118 +1,112 @@
 @mixin videoPlayer() {
-  $video-view-height: 300px;
-  $widget-size: $video-view-height * 1.77; // 16:9 aspect ratio
-  $slider-thumb-size: 16px !default;
-  $slider-track-width: calc(100% - $slider-thumb-size);
-  $slider-track-height: 10px !default;
-  $slider-thumb-offset: ($slider-thumb-size * 0.5) - ($slider-track-height * 0.5) !default;
-  $slider-thumb-hover-scale: 1.2 !default;
-  $slider-thumb-size--hover: $slider-thumb-size * $slider-thumb-hover-scale !default;
-  $slider-thumb-offset--hover: ($slider-thumb-size--hover * 0.5) - ($slider-track-height * 0.5) !default;
-
   .esri-video-player {
-    @include defaultBoxShadow();
+    --esri-video-player-view-height: 300px;
+    --esri-video-player-view-aspect-ratio: 1.77;
+    --esri-video-player-color-swatch-size: 20px;
+    --esri-video-player-color-swatch-gap: 10px;
+    --esri-video-player-progress-width: 2px;
+    --esri-video-player-controls-spacing: var(--calcite-size-16, 16px);
 
-    min-width: $widget-size;
+    min-width: calc(var(--esri-video-player-view-height) * var(--esri-video-player-view-aspect-ratio));
 
-    .esri-video-view {
+    .esri-video-player__video-view {
       display: flex;
-      height: $video-view-height;
+      height: var(--esri-video-player-view-height);
     }
 
-    .esri-slider-progress-container {
+    .esri-video-player__slider-progress-container {
       position: relative;
+      z-index: 1;
       width: 100%;
-      height: $slider-track-height;
+    }
 
-      .esri-slider {
-        .esri-slider__content {
-          justify-content: flex-start;
+    .esri-video-player__progress {
+      appearance: none;
+      display: block;
+      position: absolute;
+      top: calc(50% - var(--esri-video-player-progress-width) / 2);
+      left: var(--esri-video-player-controls-spacing);
+      border: none;
+      background: var(--calcite-color-border-1);
+      cursor: pointer;
+      width: calc(100% - var(--esri-video-player-controls-spacing) * 2);
+      height: var(--esri-video-player-progress-width);
 
-          .esri-slider__track {
-            background-color: transparent;
-            width: $slider-track-width;
-            height: $slider-track-height;
-
-            .esri-slider__segment-0 {
-              background-color: #0079c1;
-            }
-
-            .esri-slider__segment-1 {
-              background-color: transparent;
-            }
-
-            .esri-slider__thumb {
-              top: -$slider-thumb-offset;
-              left: -$slider-thumb-offset;
-              border-radius: $slider-thumb-size;
-              width: $slider-thumb-size;
-              height: $slider-thumb-size;
-
-              &:hover {
-                top: -$slider-thumb-offset--hover;
-                left: -$slider-thumb-offset--hover;
-                width: $slider-thumb-size--hover;
-                height: $slider-thumb-size--hover;
-              }
-            }
-          }
-        }
+      &::-webkit-progress-bar {
+        background-color: var(--calcite-color-border-3);
       }
 
-      .esri-progress {
-        appearance: none;
-        display: block;
-        position: absolute;
-        border: none;
-        background: $Calcite_Gray_300;
-        cursor: pointer;
-        width: 100%;
-        height: $slider-track-height;
+      &::-webkit-progress-value {
+        background-color: var(--calcite-color-border-input);
+      }
 
-        &::-webkit-progress-bar {
-          background: $Calcite_Gray_300;
+      &::-moz-progress-bar {
+        background-color: var(--calcite-color-border-3);
+      }
+    }
+
+    .esri-video-player__slider {
+      background-color: var(--calcite-color-foreground-1);
+      padding: var(--esri-video-player-controls-spacing);
+    }
+
+    .esri-video-player__slider .esri-slider {
+      .esri-slider__track {
+        background-color: transparent;
+
+        .esri-slider__segment-0 {
+          background-color: var(--calcite-color-brand);
         }
 
-        &::-webkit-progress-value {
-          background: $Calcite_Gray_350;
-        }
-
-        &::-moz-progress-bar {
-          background: $Calcite_Gray_350;
+        .esri-slider__segment-1 {
+          background-color: transparent;
         }
       }
     }
 
-    .esri-metadata-table {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-
-      &__data {
-        border-bottom: 1px solid #ccc;
-        padding: 5px;
-
-        &:last-child,
-        &:nth-last-child(2) {
-          border-bottom: none;
-        }
-      }
-    }
-
-    .esri-color-picker {
+    .esri-video-player__color-picker {
       display: grid;
       grid-template-columns: repeat(5, 1fr);
-      column-gap: 10px;
+      column-gap: var(--esri-video-player-color-swatch-gap);
 
-      .esri-color-block {
+      .esri-video-player__color-block {
         cursor: pointer;
-        width: 20px;
-        height: 20px;
+        width: var(--esri-video-player-color-swatch-size);
+        height: var(--esri-video-player-color-swatch-size);
       }
 
-      .esri-color-block__active {
-        border-radius: 20px;
+      .esri-video-player__color-block__active {
+        border-radius: var(--esri-video-player-color-swatch-size);
       }
     }
+  }
+
+  .esri-video-player__toolbar {
+    display: flex;
+    align-items: center;
+    background-color: var(--calcite-color-foreground-1);
+    padding: 0 calc(var(--esri-video-player-controls-spacing) / 2) calc(var(--esri-video-player-controls-spacing) / 2);
+    font-size: var(--calcite-font-size--2);
+  }
+
+  .esri-video-player__timecode {
+    display: flex;
+    align-items: center;
+    margin-inline: var(--calcite-size-12, 12px);
+    color: var(--calcite-color-text-3);
+  }
+
+  .esri-video-player__controls {
+    flex: 1 0 auto;
+    justify-content: flex-end;
+  }
+
+  .esri-video-player__settings-flow {
+    min-width: var(--calcite-size-160);
+  }
+
+  .esri-metadata-table__empty-state {
+    transition-duration: 0ms;
   }
 }
 

--- a/assets/esri/themes/base/widgets/_Widget.scss
+++ b/assets/esri/themes/base/widgets/_Widget.scss
@@ -300,6 +300,7 @@
   }
 
   .esri-button {
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -559,8 +560,6 @@
       overflow-y: auto;
     }
 
-    .esri-expand .esri-widget--panel,
-    .esri-expand .esri-widget--panel-height-only,
     .esri-component > .esri-widget--panel,
     .esri-component.esri-widget--panel {
       width: $panel-width;
@@ -574,8 +573,6 @@
 
   // Max heights
   .esri-view-height-greater-than-medium {
-    .esri-expand .esri-widget--panel,
-    .esri-expand .esri-widget--panel-height-only,
     .esri-ui-corner .esri-component.esri-widget--panel,
     .esri-ui-corner .esri-component.esri-widget--panel-height-only {
       max-height: $view-height--gt-medium__component-max-height;
@@ -583,8 +580,6 @@
   }
 
   .esri-view-height-medium {
-    .esri-expand .esri-widget--panel,
-    .esri-expand .esri-widget--panel-height-only,
     .esri-ui-corner .esri-component.esri-widget--panel,
     .esri-ui-corner .esri-component.esri-widget--panel-height-only {
       max-height: $view-height--medium__component-max-height;
@@ -592,8 +587,6 @@
   }
 
   .esri-view-height-small {
-    .esri-expand .esri-widget--panel,
-    .esri-expand .esri-widget--panel-height-only,
     .esri-ui-corner .esri-component.esri-widget--panel,
     .esri-ui-corner .esri-component.esri-widget--panel-height-only {
       max-height: $view-height--small__component-max-height;
@@ -601,8 +594,6 @@
   }
 
   .esri-view-height-xsmall {
-    .esri-expand .esri-widget--panel,
-    .esri-expand .esri-widget--panel-height-only,
     .esri-ui-corner .esri-component.esri-widget--panel,
     .esri-ui-corner .esri-component.esri-widget--panel-height-only {
       max-height: $view-height--xsmall__component-max-height;


### PR DESCRIPTION
Notable items:
- Updates the repo to 4.30.8.
- Removes the `master` branch for API version 3.x, as related to it being [retired as of July 1, 2024](https://www.esri.com/arcgis-blog/products/js-api-arcgis/developers/arcgis-api-for-javascript-version-3-x-retirement/).
- Adds a note to the README about the removal of 3.x.
- CatalogLayerList was added at 4.30, and the doc is missing a link to the respective scss file. That will get resolved soon.